### PR TITLE
Fixes to Top Sources Preferences pop-up

### DIFF
--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -86,7 +86,7 @@ const timespans = [
 ];
 
 const defaultPrefs = {
-  maxNumSources: "",
+  maxNumSources: "10",
   sinceDaysAgo: "7",
 };
 
@@ -249,9 +249,15 @@ const TopSources = ({ classes }) => {
   const sourceListStyles = useSourceListStyles({ invertThumbnails });
 
   const { sourceViews } = useSelector((state) => state.topSources);
-  const topSourcesPrefs =
-    useSelector((state) => state.profile.preferences.topSources) ||
-    defaultPrefs;
+
+  const userPrefs = useSelector(
+    (state) => state.profile.preferences.topSources
+  );
+  const topSourcesPrefs = userPrefs || defaultPrefs;
+
+  if (!Object.keys(topSourcesPrefs).includes("maxNumSources")) {
+    topSourcesPrefs.maxNumSources = defaultPrefs.maxNumSources;
+  }
 
   const [currentTimespan, setCurrentTimespan] = useState(
     timespans.find(
@@ -276,12 +282,12 @@ const TopSources = ({ classes }) => {
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
       <div className={classes.widgetPaperDiv}>
-        <div className={styles.header}>
+        <div>
           <Typography variant="h6" display="inline">
             Top Sources
           </Typography>
           <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
-          {/* <div className={classes.widgetIcon}>
+          <div className={classes.widgetIcon}>
             <WidgetPrefsDialog
               // Only expose num sources
               initialValues={{ maxNumSources: topSourcesPrefs.maxNumSources }}
@@ -289,7 +295,7 @@ const TopSources = ({ classes }) => {
               title="Top Sources Preferences"
               onSubmit={profileActions.updateUserPreferences}
             />
-          </div> */}
+          </div>
         </div>
         <div className={styles.timespanSelect}>
           <ButtonGroup

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -281,7 +281,7 @@ const TopSources = ({ classes }) => {
             Top Sources
           </Typography>
           <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
-          <div className={classes.widgetIcon}>
+          {/* <div className={classes.widgetIcon}>
             <WidgetPrefsDialog
               // Only expose num sources
               initialValues={{ maxNumSources: topSourcesPrefs.maxNumSources }}
@@ -289,7 +289,7 @@ const TopSources = ({ classes }) => {
               title="Top Sources Preferences"
               onSubmit={profileActions.updateUserPreferences}
             />
-          </div>
+          </div> */}
         </div>
         <div className={styles.timespanSelect}>
           <ButtonGroup


### PR DESCRIPTION
Previously just opened a pop-up with no user inputs. Now it checks if topSourcesPrefs has a "maxNumSources" key and if not adds one to guarantee that the user is queried.